### PR TITLE
feat: add shared layout and dark-first theme

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,0 +1,23 @@
+---
+import "../styles/global.css";
+
+interface Props {
+  title: string;
+}
+
+const { title } = Astro.props;
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{title}</title>
+  </head>
+  <body>
+    <div class="mx-auto max-w-2xl px-6 py-16">
+      <slot />
+    </div>
+  </body>
+</html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,44 +1,62 @@
 ---
 import { getCollection } from "astro:content";
+import Layout from "../layouts/Layout.astro";
 
 const posts = (await getCollection("posts", ({ data }) => !data.draft)).sort(
   (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
 );
 ---
 
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width" />
-    <title>Stefan Zivkovic</title>
-  </head>
-  <body>
-    <main>
-      <h1>Stefan Zivkovic</h1>
-      <ul>
-        {
-          posts.map((post) => (
-            <li>
-              <a href={`/posts/${post.id}`}>
-                <h2>{post.data.title}</h2>
-                <time datetime={post.data.date.toISOString()}>
-                  {post.data.date.toLocaleDateString("en-US", {
-                    year: "numeric",
-                    month: "long",
-                    day: "numeric",
-                  })}
-                </time>
-                <ul>
-                  {post.data.tags.map((tag) => (
-                    <li>{tag}</li>
-                  ))}
-                </ul>
-              </a>
-            </li>
-          ))
-        }
-      </ul>
-    </main>
-  </body>
-</html>
+<Layout title="Stefan Zivkovic">
+  <header class="mb-16">
+    <p class="font-mono text-sm" style="color: var(--color-accent)">
+      stefanzivkovic.dev
+    </p>
+    <h1 class="mt-2 text-2xl font-semibold tracking-tight">Stefan Zivkovic</h1>
+    <p class="mt-2 text-sm" style="color: var(--color-muted)">
+      Software engineer. Writing about code, systems, and whatever else seems
+      worth exploring.
+    </p>
+  </header>
+
+  <ul class="space-y-3">
+    {
+      posts.map((post) => (
+        <li>
+          <a
+            href={`/posts/${post.id}`}
+            class="group block rounded-lg p-5 transition-colors"
+            style="background-color: var(--color-surface); border: 1px solid var(--color-border);"
+            onmouseover="this.style.borderColor='var(--color-accent)'"
+            onmouseout="this.style.borderColor='var(--color-border)'"
+          >
+            <div class="flex items-start justify-between gap-4">
+              <h2 class="font-medium leading-snug">{post.data.title}</h2>
+              <time
+                datetime={post.data.date.toISOString()}
+                class="font-mono text-xs whitespace-nowrap"
+                style="color: var(--color-muted)"
+              >
+                {post.data.date.toLocaleDateString("en-US", {
+                  year: "numeric",
+                  month: "short",
+                  day: "numeric",
+                })}
+              </time>
+            </div>
+            <ul class="mt-3 flex flex-wrap gap-2">
+              {post.data.tags.map((tag) => (
+                <li
+                  class="font-mono text-xs px-2 py-0.5 rounded"
+                  style="background-color: var(--color-bg); color: var(--color-muted); border: 1px solid var(--color-border)"
+                >
+                  #{tag}
+                </li>
+              ))}
+            </ul>
+          </a>
+        </li>
+      ))
+    }
+  </ul>
+</Layout>

--- a/src/pages/posts/[id].astro
+++ b/src/pages/posts/[id].astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection, render } from "astro:content";
+import Layout from "../../layouts/Layout.astro";
 
 export async function getStaticPaths() {
   const posts = await getCollection("posts", ({ data }) => !data.draft);
@@ -10,26 +11,107 @@ const { post } = Astro.props;
 const { Content } = await render(post);
 ---
 
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
-    <title>{post.data.title} — Stefan Zivkovic</title>
-  </head>
-  <body>
-    <a href="/">← Back</a>
-    <article>
-      <h1>{post.data.title}</h1>
-      <time datetime={post.data.date.toISOString()}>
-        {
-          post.data.date.toLocaleDateString("en-US", {
-            year: "numeric",
-            month: "long",
-            day: "numeric",
-          })
-        }
-      </time>
+<Layout title={`${post.data.title} — Stefan Zivkovic`}>
+  <nav class="mb-12">
+    <a
+      href="/"
+      class="font-mono text-sm transition-colors"
+      style="color: var(--color-muted)"
+      onmouseover="this.style.color='var(--color-text)'"
+      onmouseout="this.style.color='var(--color-muted)'"
+    >
+      ← back
+    </a>
+  </nav>
+
+  <article>
+    <header class="mb-10">
+      <h1 class="text-2xl font-semibold leading-tight tracking-tight">
+        {post.data.title}
+      </h1>
+      <div class="mt-3 flex flex-wrap items-center gap-3">
+        <time
+          datetime={post.data.date.toISOString()}
+          class="font-mono text-xs"
+          style="color: var(--color-muted)"
+        >
+          {
+            post.data.date.toLocaleDateString("en-US", {
+              year: "numeric",
+              month: "long",
+              day: "numeric",
+            })
+          }
+        </time>
+        <ul class="flex flex-wrap gap-2">
+          {
+            post.data.tags.map((tag) => (
+              <li
+                class="font-mono text-xs px-2 py-0.5 rounded"
+                style="background-color: var(--color-surface); color: var(--color-muted); border: 1px solid var(--color-border)"
+              >
+                #{tag}
+              </li>
+            ))
+          }
+        </ul>
+      </div>
+    </header>
+
+    <div class="prose">
       <Content />
-    </article>
-  </body>
-</html>
+    </div>
+  </article>
+</Layout>
+
+<style>
+  .prose {
+    color: var(--color-text);
+    max-width: none;
+  }
+  .prose p {
+    margin-bottom: 1.25rem;
+    line-height: 1.8;
+  }
+  .prose h2,
+  .prose h3 {
+    font-weight: 600;
+    margin-top: 2rem;
+    margin-bottom: 0.75rem;
+    letter-spacing: -0.01em;
+  }
+  .prose a {
+    color: var(--color-accent);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+  .prose code {
+    font-family: var(--font-mono);
+    font-size: 0.875em;
+    background-color: var(--color-surface);
+    border: 1px solid var(--color-border);
+    padding: 0.15em 0.4em;
+    border-radius: 4px;
+  }
+  .prose pre {
+    background-color: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    padding: 1.25rem;
+    overflow-x: auto;
+    margin-bottom: 1.25rem;
+  }
+  .prose pre code {
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: 0.875rem;
+  }
+  .prose blockquote {
+    border-left: 2px solid var(--color-accent);
+    padding-left: 1rem;
+    color: var(--color-muted);
+    font-style: italic;
+    margin-bottom: 1.25rem;
+  }
+</style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,1 +1,35 @@
 @import "tailwindcss";
+
+@theme {
+  --font-mono: "JetBrains Mono", "Fira Code", "Cascadia Code", ui-monospace,
+    monospace;
+  --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
+
+  --color-bg: #0d0d0d;
+  --color-surface: #161616;
+  --color-border: #2a2a2a;
+  --color-text: #e2e2e2;
+  --color-muted: #6b6b6b;
+  --color-accent: #7c6af7;
+}
+
+@layer base {
+  html {
+    background-color: var(--color-bg);
+    color: var(--color-text);
+    font-family: var(--font-sans);
+    font-size: 16px;
+    line-height: 1.7;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  ::selection {
+    background-color: var(--color-accent);
+    color: #fff;
+  }
+}


### PR DESCRIPTION
## Summary
- Shared `Layout.astro` component eliminates HTML boilerplate duplication
- Dark-first theme via CSS custom properties (bg `#0d0d0d`, accent purple `#7c6af7`)
- Home page: card grid with hover border accent, monospace dates/tags
- Post page: prose styles for markdown (code blocks, blockquotes, headings, links)

## Test plan
- [x] Visit `/` and confirm dark background, card layout with spacing, hover effects
- [x] Click a post and confirm prose styles render correctly
- [x] Confirm `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)