### PR TITLE
chore: add .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ pnpm-debug.log*
 
 # jetbrains setting folder
 .idea/
+
+# vscode
+.vscode/


### PR DESCRIPTION
## Summary
- Excludes `.vscode/` from version control to avoid committing editor-specific settings

## Test plan
- [x] Confirm `.vscode/` no longer appears as untracked in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)