### PR TITLE
chore: improve /clean_gone to checkout main and delete all branches

### DIFF
--- a/.claude/commands/clean_gone.md
+++ b/.claude/commands/clean_gone.md
@@ -1,54 +1,38 @@
 ---
-description: Cleans up all git branches marked as [gone] (branches that have been deleted on the remote but still exist locally), including removing associated worktrees.
+description: Switch to main, pull latest, delete all non-main local branches (including gone ones and their worktrees).
 ---
 
 ## Your Task
 
-You need to execute the following bash commands to clean up stale local branches that have been deleted from the remote repository.
+Clean up local branches by switching to main and removing all other branches.
 
 ## Commands to Execute
 
-1. **First, list branches to identify any with [gone] status**
-   Execute this command:
-
+1. **Switch to main and pull latest**
    ```bash
-   git branch -v
+   git checkout main && git pull
    ```
 
-   Note: Branches with a '+' prefix have associated worktrees and must have their worktrees removed before deletion.
-
-2. **Next, identify worktrees that need to be removed for [gone] branches**
-   Execute this command:
-
+2. **Remove worktrees and delete all non-main branches**
    ```bash
-   git worktree list
-   ```
+   git fetch --prune
 
-3. **Finally, remove worktrees and delete [gone] branches (handles both regular and worktree branches)**
-   Execute this command:
-   ```bash
-   # Process all [gone] branches, removing '+' prefix if present
-   git branch -v | grep '\[gone\]' | sed 's/^[+* ]//' | awk '{print $1}' | while read branch; do
-     echo "Processing branch: $branch"
-     # Find and remove worktree if it exists
-     worktree=$(git worktree list | grep "\\[$branch\\]" | awk '{print $1}')
+   # Delete [gone] branches (worktrees first)
+   git branch -vv | grep '\[gone\]' | sed 's/^[+* ]*//' | awk '{print $1}' | while read branch; do
+     worktree=$(git worktree list | grep "\[$branch\]" | awk '{print $1}')
      if [ ! -z "$worktree" ] && [ "$worktree" != "$(git rev-parse --show-toplevel)" ]; then
-       echo "  Removing worktree: $worktree"
        git worktree remove --force "$worktree"
      fi
-     # Delete the branch
-     echo "  Deleting branch: $branch"
      git branch -D "$branch"
    done
+
+   # Delete all remaining non-main branches
+   git branch | grep -v '^\* main' | xargs -r git branch -d
    ```
 
 ## Expected Behavior
 
-After executing these commands, you will:
-
-- See a list of all local branches with their status
-- Identify and remove any worktrees associated with [gone] branches
-- Delete all branches marked as [gone]
-- Provide feedback on which worktrees and branches were removed
-
-If no branches are marked as [gone], report that no cleanup was needed.
+- Switched to main and pulled latest
+- All non-main local branches deleted
+- Worktrees for gone branches removed
+- Report what was cleaned up, or confirm nothing needed cleaning


### PR DESCRIPTION
## Summary
- `/clean_gone` now checks out main and pulls latest before cleaning up
- Deletes all non-main local branches, not just [gone] ones
- Simplified command structure

## Test plan
- [x] Run `/clean_gone` while on a feature branch and confirm it switches to main
- [x] Confirm all non-main branches are removed after running

🤖 Generated with [Claude Code](https://claude.com/claude-code)