### PR TITLE
feat: add reading time to post cards and post page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,10 +1,19 @@
 ---
-import { getCollection } from "astro:content";
+import { getCollection, render } from "astro:content";
 import Layout from "../layouts/Layout.astro";
 
-const posts = (await getCollection("posts", ({ data }) => !data.draft)).sort(
-  (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
+const allPosts = await getCollection("posts", ({ data }) => !data.draft);
+
+const posts = await Promise.all(
+  allPosts.map(async (post) => {
+    const { remarkPluginFrontmatter } = await render(post);
+    const wordCount = post.body?.split(/\s+/).filter(Boolean).length ?? 0;
+    const readingTime = Math.max(1, Math.round(wordCount / 200));
+    return { ...post, readingTime };
+  }),
 );
+
+posts.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 ---
 
 <Layout title="Stefan Zivkovic">
@@ -32,17 +41,19 @@ const posts = (await getCollection("posts", ({ data }) => !data.draft)).sort(
           >
             <div class="flex items-start justify-between gap-4">
               <h2 class="font-medium leading-snug">{post.data.title}</h2>
-              <time
-                datetime={post.data.date.toISOString()}
-                class="font-mono text-xs whitespace-nowrap"
+              <div
+                class="font-mono text-xs whitespace-nowrap flex gap-3"
                 style="color: var(--color-muted)"
               >
-                {post.data.date.toLocaleDateString("en-US", {
-                  year: "numeric",
-                  month: "short",
-                  day: "numeric",
-                })}
-              </time>
+                <span>{post.readingTime} min read</span>
+                <time datetime={post.data.date.toISOString()}>
+                  {post.data.date.toLocaleDateString("en-US", {
+                    year: "numeric",
+                    month: "short",
+                    day: "numeric",
+                  })}
+                </time>
+              </div>
             </div>
             <ul class="mt-3 flex flex-wrap gap-2">
               {post.data.tags.map((tag) => (

--- a/src/pages/posts/[id].astro
+++ b/src/pages/posts/[id].astro
@@ -9,6 +9,8 @@ export async function getStaticPaths() {
 
 const { post } = Astro.props;
 const { Content } = await render(post);
+const wordCount = post.body?.split(/\s+/).filter(Boolean).length ?? 0;
+const readingTime = Math.max(1, Math.round(wordCount / 200));
 ---
 
 <Layout title={`${post.data.title} — Stefan Zivkovic`}>
@@ -43,6 +45,9 @@ const { Content } = await render(post);
             })
           }
         </time>
+        <span class="font-mono text-xs" style="color: var(--color-muted)">
+          {readingTime} min read
+        </span>
         <ul class="flex flex-wrap gap-2">
           {
             post.data.tags.map((tag) => (


### PR DESCRIPTION
## Summary
- Reading time calculated at build time from word count (200 wpm, min 1 min)
- Shown on home page cards alongside the date
- Shown on post page header alongside date and tags

## Test plan
- [x] Visit `/` and confirm each card shows "X min read"
- [x] Visit a post and confirm reading time appears in the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)