### PR TITLE
fix: remove TypeScript cast from is:inline search script

### DIFF
--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -75,7 +75,7 @@ import Layout from "../layouts/Layout.astro";
     const input = document.getElementById("search-input");
     if (input) {
       input.addEventListener("input", (e) => {
-        ui.triggerSearch((e.target as HTMLInputElement).value);
+        ui.triggerSearch(e.target.value);
       });
     }
   };


### PR DESCRIPTION
## Summary
- Removes `as HTMLInputElement` TypeScript cast from the `<script is:inline>` block in `search.astro`
- This cast caused `Uncaught SyntaxError: Unexpected identifier 'as'` in production because `is:inline` scripts are not processed by TypeScript/Vite

## Test plan
- [ ] Deploy to Vercel preview and navigate to `/search`
- [ ] Verify no console errors on page load
- [ ] Type in the search box and confirm results appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)